### PR TITLE
using Dynamic Map Service instead of WebMap

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,39 +90,64 @@
       "application/TableOfContents",
       "esri/arcgis/utils",
       "dojo/on",
-      "dojo/dom"
+      "dojo/dom",
+      "esri/map",
+      "esri/layers/ArcGISDynamicMapServiceLayer"
     ], function (
       lang,
       esriConfig,
       TableOfContents,
       arcgisUtils,
       on,
-      dom
+      dom,
+      Map,
+      ArcGISDynamicMapServiceLayer
     ) {
 
 
-      // esriConfig.defaults.io.proxyUrl = "/proxy/proxy.php";
+      // RUN DIRECT MAP SERVICE
+      // var map = new Map("map", {
+      //     basemap: "topo",  
+      //     center: [-122.45, 37.75], 
+      //     zoom: 13
+      // });
+      //   //Takes a URL to a non cached map service.
+      //   var dynamicMapServiceLayer = new ArcGISDynamicMapServiceLayer("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer", {
+      //     "opacity" : 0.5        
+      //   });
+      //   map.addLayer(dynamicMapServiceLayer);   
+      //       myWidget = new TableOfContents({
+      //         map: map,
+      //         layers: map._layers
+      //       }, "TableOfContents");
+      //   myWidget.startup();
+      // END RUN DIRECT MAP SERVICE
 
 
-      /* Sample apps */
 
-      // 62c2a1a6ac8f4329b34d3dcf7ad47099 - devext
+      // RUN WEBMAP 
+      // // esriConfig.defaults.io.proxyUrl = "/proxy/proxy.php";
 
-      // b591577a424242e8ae4667de053c3ffa - csv layer
 
-      // df8bcc10430f48878b01c96e907a1fc3 - wildfire
+      // /* Sample apps */
 
-      // c46382e26f81477ca0046d376b2989fa - georss
+      // // 62c2a1a6ac8f4329b34d3dcf7ad47099 - devext
 
-      // e90e7933b68a43988b04fe800d0330ba - wms
+      // // b591577a424242e8ae4667de053c3ffa - csv layer
+
+      // // df8bcc10430f48878b01c96e907a1fc3 - wildfire
+
+      // // c46382e26f81477ca0046d376b2989fa - georss
+
+      // // e90e7933b68a43988b04fe800d0330ba - wms
       
-      // 72748e2e531f400cbe5a7560f768bdb8 - federal lands
+      // // 72748e2e531f400cbe5a7560f768bdb8 - federal lands
 
-      // arcgisUtils.arcgisUrl = "http://kd.mapsdevext.arcgis.com/sharing/rest/content/items";
+      // // arcgisUtils.arcgisUrl = "http://kd.mapsdevext.arcgis.com/sharing/rest/content/items";
 
 
 
-      /* Create webmap */
+      // /* Create webmap */
 
       arcgisUtils.createMap('df8bcc10430f48878b01c96e907a1fc3', "map", {
         mapOptions: {
@@ -204,6 +229,9 @@
           alert("Unable to create map: " + error.message);
         }
       }));
+      // END RUN WEBMAP 
+
+
     });
   </script>
 </body>

--- a/js/TableOfContents.js
+++ b/js/TableOfContents.js
@@ -125,6 +125,7 @@ define([
 
       refresh: function () {
         // all layer info
+         this.layers = this.get("map").getLayersVisibleAtScale();
         var layers = this.layers;
         // store nodes here
         this._nodes = [];
@@ -271,7 +272,8 @@ define([
               var subNodes = [];
               var layerType = layerInfo.layerType;
               // get parent layer checkbox status
-              var status = this._checkboxStatus(layerInfo);
+              var status = this._serviceLayerCheckboxStatus(layer);
+              //var status = this._checkboxStatus(layerInfo);
               // title container
               var titleContainerNode = domConstruct.create("div", {
                 className: this.css.titleContainer
@@ -358,6 +360,10 @@ define([
                     else if (layerType === "WMS") {
                       subLayerIndex = subLayer.name;
                       parentId = -1;
+                    }
+                    else { 
+                      subLayerIndex = subLayer.id;
+                      parentId = subLayer.parentLayerId;
                     }
                     // place subLayers not in the root
                     if (parentId !== -1) {
@@ -521,6 +527,9 @@ define([
           var layerInfo = this.layers[parseInt(layerIndex, 10)];
           var layerType = layerInfo.layerType;
           var layer = layerInfo.layerObject;
+          if(layer===undefined){
+            layer = layerInfo;
+          }
           var featureCollection = layerInfo.featureCollection;
           var visibleLayers;
           var i;
@@ -542,7 +551,7 @@ define([
             // we're toggling a sublayer
             if (subLayerIndex !== null) {
               // Map Service Layer
-              if (layerType === "ArcGISMapServiceLayer") {
+              if (layerType === "ArcGISMapServiceLayer" || layerType == undefined) {
                 subLayerIndex = parseInt(subLayerIndex, 10);
                 var layerInfos = layer.layerInfos;
                 // array for setting visible layers
@@ -655,6 +664,10 @@ define([
         if (equal) {
           this._toggleVisible(index, null, visible);
         }
+      },
+
+      _serviceLayerCheckboxStatus: function (layer) {
+        return layer.visible || false;
       },
 
       _setLayerEvents: function () {


### PR DESCRIPTION
I have made starting changes to the TableOfContents.js to allow it to be
used with ArcGISDynamicMapServices instead of WebMap versions of
services. I have also added the option of creating the map directly in
the index.html instead of webmap just for testing...

The primary changes are pulling the layer objec directly if the layer.layerObject is undefined (same for layerInfo)

Also layerType is always null in these situations. I haven't seen an easy way to determine the LayerType when using the layers directly. So I am defaulting to ArcGISMapServiceLayer, but this could probably be improved.