### PR TITLE
Update LayerList.js for refresh when layers added after map is loaded

### DIFF
--- a/js/LayerList.js
+++ b/js/LayerList.js
@@ -84,6 +84,7 @@ define([
           // toggle layer visibility
           _self._toggleLayer(data, subData);
         }));
+        this._setMapEvents();
       },
 
       // start widget. called by user
@@ -179,6 +180,23 @@ define([
           def.resolve(evt);
         }
         return def.promise;
+      },
+      
+      _setMapEvents: function() {
+        this.own(on(this.map, "layer-add", lang.hitch(this, function() {
+          this._updateAllMapLayers();
+          this.refresh().always(lang.hitch(this, function() {
+            this.set("loaded", true);
+            this.emit("load");
+          }));
+        })));
+        this.own(on(this.map, "layer-remove", lang.hitch(this, function() {
+          this._updateAllMapLayers();
+          this.refresh().always(lang.hitch(this, function() {
+            this.set("loaded", true);
+            this.emit("load");
+          }));
+        })));
       },
 
       _checkboxStatus: function (layerInfo) {
@@ -739,7 +757,7 @@ define([
       },
 
       _updateAllMapLayers: function () {
-        if (this.map && (!this.layers || !this.layers.length)) {
+        //if (this.map && (!this.layers || !this.layers.length)) {
           var layers = [];
           // get all non graphic layers
           array.forEach(this.map.layerIds, function (layerId) {
@@ -757,7 +775,7 @@ define([
             }
           }, this);
           this._set("layers", layers);
-        }
+       // }
       },
 
       _init: function () {


### PR DESCRIPTION
Update LayerList.js for refresh when layers added after map is loaded
- Adding ability to see map services added after initial load.
- Added button for testing on map.html
- Added back _setMapEvents() method.
  This works, however it is causing some extra loops. Open to ideas on improvement...
  I am calling the UpdateMapLayers on a layer add.. and adding the setmapEvents() in the postCreate() method..
  (had to note out two lines in UpdateMapLayers)

my notes on the basic order of methods on load
postcreate()
startup()
maploaded ()
init()- 
updateallmaplayers()
refresh() -
layerloaded()
createLayerNodes()
removeevents()
